### PR TITLE
[inject] bump engines.node 18.x -> 22.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
         with:
-          node-version: '18.20.4'
+          node-version: '22.11.0'
           cache: 'npm'
           cache-dependency-path: src/Web/package-lock.json
 

--- a/src/Web/.npmrc
+++ b/src/Web/.npmrc
@@ -1,0 +1,3 @@
+# Injected by scripts/inject-dep-conflict.ps1.
+# engine-strict turns engines mismatches into hard errors at install time.
+engine-strict=true

--- a/src/Web/package.json
+++ b/src/Web/package.json
@@ -5,7 +5,7 @@
   "description": "Tiny Express fixture for selfheal-experiments. Intentionally boring.",
   "main": "index.js",
   "engines": {
-    "node": "18.x"
+    "node": "22.x"
   },
   "scripts": {
     "start": "node index.js",


### PR DESCRIPTION
Automated injection from `scripts/inject-dep-conflict.ps1`.

- Bumped `src/Web/package.json` engines.node: `18.x` -> `22.x`
- Bumped CI `node-version`: `18.20.4` -> `22.11.0`
- Added `src/Web/.npmrc` with `engine-strict=true`

Expectation: CI fails. Self-heal responder will open a tracking issue and assign
the cloud agent. Do **not** auto-merge.