### PR TITLE
[inject] bump Node 18.x -> 22.x + add legacy crypto helper

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
         with:
-          node-version: '18.20.4'
+          node-version: '22.11.0'
           cache: 'npm'
           cache-dependency-path: src/Web/package-lock.json
 

--- a/src/Web/crypto-helper.js
+++ b/src/Web/crypto-helper.js
@@ -1,0 +1,24 @@
+'use strict';
+
+// Sign an opaque session token. Implementation predates Node 22.
+//
+// Note: crypto.createCipher is a legacy API. It derives a key from the
+// passphrase via OpenSSL's EVP_BytesToKey, which is not considered secure
+// for new code. Kept here for backward-compatibility with tokens issued by
+// the previous version of this service.
+const crypto = require('crypto');
+
+const ALGO = 'aes-192-cbc';
+
+function signToken(payload, passphrase) {
+  const cipher = crypto.createCipher(ALGO, passphrase);
+  let out = cipher.update(payload, 'utf8', 'hex');
+  out += cipher.final('hex');
+  return out;
+}
+
+function verifyToken(token, payload, passphrase) {
+  return signToken(payload, passphrase) === token;
+}
+
+module.exports = { signToken, verifyToken };

--- a/src/Web/crypto-helper.test.js
+++ b/src/Web/crypto-helper.test.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const { signToken, verifyToken } = require('./crypto-helper');
+
+describe('crypto-helper', () => {
+  test('signToken is deterministic for the same passphrase', () => {
+    const a = signToken('user-42', 'shared-secret');
+    const b = signToken('user-42', 'shared-secret');
+    expect(a).toBe(b);
+  });
+
+  test('verifyToken accepts a freshly signed token', () => {
+    const token = signToken('user-42', 'shared-secret');
+    expect(verifyToken(token, 'user-42', 'shared-secret')).toBe(true);
+  });
+});

--- a/src/Web/package.json
+++ b/src/Web/package.json
@@ -5,7 +5,7 @@
   "description": "Tiny Express fixture for selfheal-experiments. Intentionally boring.",
   "main": "index.js",
   "engines": {
-    "node": "18.x"
+    "node": "22.x"
   },
   "scripts": {
     "start": "node index.js",


### PR DESCRIPTION
Automated injection from `scripts/inject.ps1`.

- Bumped `src/Web/package.json` engines.node: `18.x` -> `22.x`
- Bumped CI `node-version`: `18.20.4` -> `22.11.0`
- Added `src/Web/crypto-helper.js` (uses `crypto.createCipher`)
- Added `src/Web/crypto-helper.test.js`

Expectation: CI fails. `crypto.createCipher` was hard-removed in Node 22, so
`require('./crypto-helper')` throws TypeError when jest loads the test file.
Self-heal responder will open a tracking issue and assign the cloud agent.
Do **not** auto-merge.