### PR TITLE
Add @-mention-PR-author handoff demo

### DIFF
--- a/.github/DEMO_CI_FAILURE_TEMPLATE.md
+++ b/.github/DEMO_CI_FAILURE_TEMPLATE.md
@@ -1,0 +1,70 @@
+# CI failure — automated tracking issue (demo)
+
+> Opened by `.github/workflows/demo-self-heal.yml` after a failed CI run on
+> a `demo/*` branch. Variables below are substituted server-side via
+> `envsubst`.
+
+@${PR_AUTHOR} — CI failed on your PR. **Please assign Copilot to start the
+fix** (one click; see "Assign Copilot" below). This is a deliberate
+human-in-the-loop step; the workflow cannot do it for you.
+
+**Source PR:** [#${PR_NUMBER}](${PR_URL})
+**Workflow:** `${WORKFLOW_NAME}`
+**Failed job:** `${FAILED_JOB_NAME}`
+**Branch:** `${HEAD_BRANCH}`
+**Commit:** `${HEAD_SHA}`
+**Run:** [#${RUN_NUMBER} (attempt ${RUN_ATTEMPT})](${RUN_URL})
+**Triggered by:** `${TRIGGERING_ACTOR}`
+
+## Assign Copilot to start the fix
+
+Use either:
+
+- **GitHub UI** — open this issue and pick **Copilot** from the Assignees
+  sidebar.
+- **Command line** — from a shell authenticated as your GitHub user:
+
+  ```bash
+  gh issue edit <THIS_ISSUE_NUMBER> --add-assignee copilot-swe-agent
+  ```
+
+  (Replace `<THIS_ISSUE_NUMBER>` with the number shown in this issue's URL;
+  the workflow can't substitute its own future number into its own body.)
+
+### Why a human click?
+
+GitHub App installation tokens **cannot** assign the Copilot cloud agent
+(`copilot-swe-agent`). Per
+[GitHub's docs](https://docs.github.com/en/copilot/how-tos/use-copilot-agents/cloud-agent/create-a-pr#assigning-an-issue-to-copilot-via-the-github-api),
+assignment requires a personal access token or a GitHub App user-to-server
+token — both of which are stored user credentials with the same business
+continuity problem (what happens when the user leaves?).
+
+This demo accepts the one-click handoff so the responder does not have to
+hold a long-lived user credential. See
+[`.github/skills/selfheal-demo/README.md`](./skills/selfheal-demo/README.md) for the full design tradeoff.
+
+## Reproduce locally
+
+```bash
+cd src/Web
+npm ci
+npm test
+```
+
+## Last 50 log lines
+
+<!-- 4-tilde fence so log content containing triple backticks cannot break it. -->
+~~~~text
+${LOG_TAIL}
+~~~~
+
+## Rollback (if needed)
+
+```bash
+git revert ${HEAD_SHA}
+git push origin ${HEAD_BRANCH}
+```
+
+---
+<sub>Dedupe key: `sh-${DEDUPE_KEY}` · demo</sub>

--- a/.github/skills/selfheal-demo/README.md
+++ b/.github/skills/selfheal-demo/README.md
@@ -1,0 +1,177 @@
+# Self-heal demo: the @-mention-PR-author handoff
+
+A repeatable, customer-facing walkthrough of one specific pattern for
+self-healing CI: when CI fails, open a tracking issue that **@-mentions
+the PR author with a one-click `gh` snippet**, and let the human assign
+the GitHub Copilot cloud agent. No PAT. No long-lived OAuth refresh
+token. One human click.
+
+## What you'll see
+
+1. `pwsh .github/skills/selfheal-demo/run-demo.ps1` opens a
+   deliberately-broken PR (`[demo] Self-heal walkthrough: Node 22 +
+   crypto.createCipher`).
+2. CI fails on that PR within ~30 s.
+3. The `Demo Self-heal` workflow opens a tracking issue that mentions
+   the PR author and includes a copy-paste `gh issue edit … --add-assignee
+   copilot-swe-agent` snippet, **and** posts a comment on the source PR
+   linking to the tracking issue.
+4. You (or the PR author) assign Copilot to the tracking issue. The
+   agent opens a fix PR off `main` within ~10 min (Batch 1 median: 8 min).
+
+## Why this design
+
+The Copilot cloud agent only starts when assigned to an issue, and
+[GitHub explicitly requires a user identity for that
+assignment](https://docs.github.com/en/copilot/how-tos/use-copilot-agents/cloud-agent/create-a-pr#assigning-an-issue-to-copilot-via-the-github-api).
+Confirmed empirically in this repo: GitHub App installation tokens
+silently fail (REST returns 201 but drops the bot; GraphQL hard-errors).
+A PAT or App user-to-server token works — but both are stored user
+credentials with the same business-continuity problem (what happens when
+the user leaves?).
+
+This pattern accepts the loss of unattended dispatch in exchange for
+**no stored user credentials**. The PR author is the natural party to
+click "assign" — they were going to look at the failure anyway.
+
+### What this demo deliberately is *not*
+
+- Not a circuit breaker, not a retry strategy, not a transient-failure
+  filter. (See the predecessor at tag `v0-governance-reference` if you
+  want those.)
+- Not a multi-scenario classifier. One scenario, picked because it has
+  validated 5/5 success in unguided trials (see
+  [`../experiments/README.md`](../experiments/README.md), Batch 1).
+- Not auto-merging the agent's fix. Human still reviews.
+
+## Architecture
+
+```
+┌──────────────┐  push   ┌──────────┐  failure   ┌──────────────────┐
+│ PR author    │────────►│   CI     │───────────►│ Demo Self-heal   │
+│ (you)        │         │ workflow │            │    workflow      │
+└──────┬───────┘         └──────────┘            └────────┬─────────┘
+       │                                                  │
+       │             ┌────────────────────────────────────┤
+       │             │ open issue (@-mention author)      │
+       │             │ comment on source PR with link     │
+       │             ▼                                    │
+       │      ┌──────────────┐                            │
+       │      │ tracking     │                            │
+       │      │ issue        │                            │
+       │      └──────┬───────┘                            │
+       │ (1 click)   │                                    │
+       └────────────►│ assign copilot-swe-agent           │
+                     ▼                                    │
+              ┌──────────────┐                            │
+              │ Copilot      │  opens fix PR off main     │
+              │ cloud agent  │───────────────────────────►│
+              └──────────────┘                            │
+                                                          ▼
+                                                   ┌──────────┐
+                                                   │ fix PR   │
+                                                   │ (review) │
+                                                   └──────────┘
+```
+
+Demo scope is the path between **CI failure** and **agent assignment**.
+The agent's fix PR and your review of it are outside the responder's
+scope.
+
+## Run it yourself
+
+### Prerequisites
+
+- The repo-level setup in [`../../../README.md`](../../../README.md) is complete:
+  - `selfheal-orchestrator-mjh` GitHub App installed.
+  - Repo variable `APP_ID` and secret `APP_PRIVATE_KEY` set.
+  - Actions permissions: read+write, allow PR approval.
+  - Copilot is in `suggestedActors(CAN_BE_ASSIGNED)` for this repo.
+- Local: `git`, `gh` (authenticated as a **user**, not just an App), and
+  `pwsh` (Windows/macOS/Linux) **or** `bash`.
+- A clean clone, but you do **not** need a clean working tree on `main`
+  — the runner uses a sibling worktree and never touches your checkout.
+
+### One command
+
+```pwsh
+pwsh .github/skills/selfheal-demo/run-demo.ps1
+```
+
+or
+
+```bash
+.github/skills/selfheal-demo/run-demo.sh
+```
+
+The script prints the demo PR URL and the `gh issue edit` snippet to
+copy once the tracking issue appears.
+
+### Expected timeline
+
+| Step | Wallclock |
+|---|---|
+| `run-demo` opens demo PR | < 5 s |
+| CI fails on the demo PR | ~30 s after push |
+| `Demo Self-heal` workflow runs (issue + PR comment) | ~30 s after CI fails |
+| You click "assign Copilot" | (manual; the demo's payload) |
+| Agent opens fix PR | ~3–10 min after assignment (Batch 1 median: 8 min) |
+| Agent CI runs (may need rerun, see below) | ~1 min once unblocked |
+
+**Heads-up on bot CI runs.** GitHub gates first-party-bot-authored CI
+runs (`action_required`) by default; you may need to click "Approve and
+run workflows" on the agent's fix PR. This is repo-wide GitHub
+behaviour, not a defect of the demo.
+
+## Reset
+
+```pwsh
+pwsh .github/skills/selfheal-demo/reset-demo.ps1
+```
+
+or
+
+```bash
+.github/skills/selfheal-demo/reset-demo.sh
+```
+
+Closes the demo PR (and its branch), closes the tracking issue,
+removes the worktree, deletes any lingering `demo/*` remote branches,
+and prunes worktree metadata. Idempotent.
+
+> **Tip.** If you abandon a fix PR halfway through (agent still
+> running), close it manually first; otherwise `reset-demo` will leave
+> it open (the filter is `[demo]` titles only, and Copilot's PRs don't
+> use that prefix).
+
+## Use from VS Code chat
+
+This directory **is** the skill — VS Code auto-discovers skills under
+`.github/skills/<name>/`, so [`SKILL.md`](SKILL.md) is live as soon as
+you open the workspace. After that:
+
+> "Run the self-heal demo."
+> "Reset the self-heal demo."
+
+The skill wraps the same scripts and surfaces their output back into
+chat.
+
+## Files
+
+| Path | Role |
+|---|---|
+| [run-demo.ps1](run-demo.ps1) / [run-demo.sh](run-demo.sh) | Inject + push + open PR; records state under `.state/` (gitignored). |
+| [reset-demo.ps1](reset-demo.ps1) / [reset-demo.sh](reset-demo.sh) | Idempotent cleanup. |
+| [SKILL.md](SKILL.md) | Chat-invokable wrapper (auto-discovered from `.github/skills/`). |
+| [`../../workflows/demo-self-heal.yml`](../../workflows/demo-self-heal.yml) | Demo responder workflow (scoped to `demo/*` branches). |
+| [`../../DEMO_CI_FAILURE_TEMPLATE.md`](../../DEMO_CI_FAILURE_TEMPLATE.md) | Tracking-issue template (with `@author` mention + `gh` snippet). |
+
+## Relationship to the experiment harness
+
+The repo's experiment workflow (`.github/workflows/self-heal.yml`)
+**ignores `demo/*` branches** so trial data stays comparable across
+batches. The demo lives entirely in `.github/skills/selfheal-demo/` and
+`.github/workflows/demo-self-heal.yml`. The fixture (`src/Web/`) and
+inject mutations are shared; the runner deliberately duplicates the
+mutation block from `scripts/inject.ps1` rather than refactor a shared
+helper, again to keep the experiment scripts byte-stable.

--- a/.github/skills/selfheal-demo/SKILL.md
+++ b/.github/skills/selfheal-demo/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: selfheal-demo
+description: 'Run or reset the self-heal walkthrough demo in this repo. USE FOR: showing the @-mention-PR-author handoff pattern end-to-end (inject a CI failure, watch the demo workflow open a tracking issue and PR comment, then assign Copilot manually). Trigger phrases: "run the self-heal demo", "demo the self-healing pattern", "show the selfheal-experiments demo", "reset the self-heal demo", "clean up the self-heal demo". Wraps run-demo.ps1 and reset-demo.ps1 (next to this SKILL.md). DO NOT USE FOR: experiment trials (use scripts/inject.ps1 + experiments/trials.jsonl); fixture changes; workflow changes.'
+---
+
+# selfheal-demo
+
+Drives the customer-facing walkthrough packaged with this skill. The skill
+lives at `.github/skills/selfheal-demo/` and VS Code auto-discovers it from
+that location — no manual install step.
+
+## Operations
+
+### `run` — start a demo run
+
+Run when the user asks to start, run, kick off, or trigger the demo.
+
+1. **Pre-flight** — verify all of:
+   - Current working directory is the `selfheal-experiments` repo root
+     (check for `.github/skills/selfheal-demo/run-demo.ps1`).
+   - `gh auth status` reports an authenticated **user** (not just an App).
+     If not, stop and tell the user — App tokens cannot assign Copilot,
+     which is the entire point of the demo.
+   - No open `[demo]` PR already exists. (`gh pr list --state open
+     --search '"[demo]" in:title' --json number --jq 'length'` returns 0.)
+     If one exists, ask whether to reset first; do not silently `-Force`.
+2. **Invoke** — run `pwsh .github/skills/selfheal-demo/run-demo.ps1` from
+   the repo root. (On non-Windows: `bash
+   .github/skills/selfheal-demo/run-demo.sh`.) The user's working tree is
+   never modified — the script uses a sibling worktree.
+3. **Report** — surface the script's printed output to the user, in
+   particular:
+   - The demo PR URL.
+   - The expected wait (~30 s for CI to fail; ~8 min median for the
+     agent's fix PR after manual assignment).
+   - The exact `gh issue edit <NUMBER> --add-assignee copilot-swe-agent`
+     snippet, with `<NUMBER>` left as a placeholder until the tracking
+     issue actually appears.
+4. **Do NOT** attempt to assign Copilot programmatically. The manual
+   click is the demo's payload.
+
+### `reset` — clean up after a run
+
+Run when the user asks to reset, clean up, tear down, or repeat the demo.
+
+1. Invoke `pwsh .github/skills/selfheal-demo/reset-demo.ps1 -Force` (skill
+   always passes `-Force` — the user already asked for the reset by
+   invoking the skill).
+2. Surface the printed output. The script is idempotent; "nothing to
+   clean" is a success path.
+
+## Pre-flight checklist (both operations)
+
+- `git` and `gh` on PATH.
+- Repo has the App installed and `Demo Self-heal` workflow present at
+  `.github/workflows/demo-self-heal.yml`.
+- Authenticated `gh` user has access to the repo.
+
+## Files this skill touches
+
+- Reads / executes (next to this SKILL.md):
+  [run-demo.ps1](run-demo.ps1), [run-demo.sh](run-demo.sh),
+  [reset-demo.ps1](reset-demo.ps1), [reset-demo.sh](reset-demo.sh).
+- Reads only (for context if the user asks why something happened):
+  [README.md](README.md),
+  [../../workflows/demo-self-heal.yml](../../workflows/demo-self-heal.yml),
+  [../../DEMO_CI_FAILURE_TEMPLATE.md](../../DEMO_CI_FAILURE_TEMPLATE.md).
+
+## Anti-patterns
+
+- **Do not** edit the workflow or the inject scripts to make the demo
+  "more reliable." The current fixture has 5/5 success in Batch 1; the
+  variability sits with the agent, not the harness.
+- **Do not** attempt to bypass the manual assignment step by introducing
+  a PAT or OAuth user-to-server token. That defeats the point of the
+  walkthrough — see [README.md](README.md).
+- **Do not** run `reset` while a Copilot fix-PR session is in progress;
+  the agent will lose context. Wait for the fix PR to be opened (or
+  abandoned) first.

--- a/.github/skills/selfheal-demo/reset-demo.ps1
+++ b/.github/skills/selfheal-demo/reset-demo.ps1
@@ -1,0 +1,129 @@
+<#
+.SYNOPSIS
+    Clean up everything created by .github/skills/selfheal-demo/run-demo.ps1.
+
+.DESCRIPTION
+    Idempotent. Safe to re-run. "Nothing to clean" is a success path.
+
+    Cleans up, in order:
+      1. Open PRs whose title starts with `[demo]` -> close + delete branch.
+      2. Open issues with the `self-heal` label whose title contains `[demo]`
+         -> close.
+      3. Worktrees recorded in .github/skills/selfheal-demo/.state/*.json
+         -> git worktree remove --force, then delete the state file.
+      4. Fallback: any worktree at git's worktree list whose branch matches
+         demo/* -> git worktree remove --force (covers state-file loss).
+      5. Any remaining `demo/*` branches on the remote -> push delete.
+      6. `git worktree prune`.
+
+.PARAMETER Force
+    Skip the destructive-action confirmation prompt. Used by the chat skill.
+#>
+[CmdletBinding()]
+param(
+    [switch] $Force
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+foreach ($cmd in @('git', 'gh')) {
+    if (-not (Get-Command $cmd -ErrorAction SilentlyContinue)) {
+        throw "Required command not found in PATH: $cmd"
+    }
+}
+
+$repoRoot = (git rev-parse --show-toplevel).Trim()
+if (-not $repoRoot) { throw 'Not inside a git repo.' }
+Set-Location $repoRoot
+
+if (-not $Force) {
+    Write-Host 'This will close demo PRs/issues, delete demo/* branches on the remote,'
+    Write-Host 'and force-remove demo worktrees. Re-run with -Force to skip this prompt.'
+    $resp = Read-Host 'Proceed? [y/N]'
+    if ($resp -notmatch '^(y|Y|yes)$') {
+        Write-Host 'Aborted.'
+        return
+    }
+}
+
+# --- 1. close demo PRs ----------------------------------------------------
+$demoPrs = gh pr list --state open --search '"[demo]" in:title' --json number,title,headRefName --jq '.' | ConvertFrom-Json
+if ($demoPrs) {
+    foreach ($pr in @($demoPrs)) {
+        Write-Host "Closing PR #$($pr.number) ($($pr.title))"
+        gh pr close $pr.number --delete-branch --comment 'Closed by reset-demo.ps1.' 2>$null | Out-Null
+    }
+} else {
+    Write-Host 'No open demo PRs.'
+}
+
+# --- 2. close demo tracking issues ----------------------------------------
+$demoIssues = gh issue list --state open --label self-heal --search '"[demo]" in:title' --json number,title --jq '.' | ConvertFrom-Json
+if ($demoIssues) {
+    foreach ($iss in @($demoIssues)) {
+        Write-Host "Closing issue #$($iss.number) ($($iss.title))"
+        gh issue close $iss.number --comment 'Closed by reset-demo.ps1.' 2>$null | Out-Null
+    }
+} else {
+    Write-Host 'No open demo tracking issues.'
+}
+
+# --- 3. remove worktrees recorded in state files --------------------------
+$stateDir = Join-Path $repoRoot '.github/skills/selfheal-demo/.state'
+$cleanedWorktrees = @{}
+if (Test-Path $stateDir) {
+    Get-ChildItem -Path $stateDir -Filter '*.json' -ErrorAction SilentlyContinue | ForEach-Object {
+        try {
+            $st = Get-Content $_.FullName -Raw | ConvertFrom-Json
+            if ($st.worktree -and (Test-Path $st.worktree)) {
+                Write-Host "Removing worktree: $($st.worktree)"
+                git worktree remove --force $st.worktree 2>$null | Out-Null
+            }
+            if ($st.worktree) { $cleanedWorktrees[$st.worktree] = $true }
+        } catch {
+            Write-Host "Skipping unreadable state file: $($_.Name) ($($_.Exception.Message))"
+        }
+        Remove-Item $_.FullName -Force
+    }
+}
+
+# --- 4. fallback worktree scan -------------------------------------------
+$wtList = git worktree list --porcelain 2>$null
+$current = @{}
+foreach ($line in ($wtList -split "`n")) {
+    if ($line -match '^worktree (.+)$')   { if ($current.path) { } ; $current = @{ path = $matches[1] } }
+    elseif ($line -match '^branch (.+)$') { $current.branch = $matches[1] }
+    elseif ($line.Trim() -eq '' -and $current.Count -gt 0) {
+        if ($current.branch -and $current.branch -match 'refs/heads/demo/' -and -not $cleanedWorktrees.ContainsKey($current.path)) {
+            Write-Host "Removing stray demo worktree: $($current.path)"
+            git worktree remove --force $current.path 2>$null | Out-Null
+        }
+        $current = @{}
+    }
+}
+if ($current.branch -and $current.branch -match 'refs/heads/demo/' -and -not $cleanedWorktrees.ContainsKey($current.path)) {
+    Write-Host "Removing stray demo worktree: $($current.path)"
+    git worktree remove --force $current.path 2>$null | Out-Null
+}
+
+# --- 5. delete remaining demo/* remote branches ---------------------------
+git fetch --prune origin --quiet
+$remoteDemoBranches = (git branch -r --list 'origin/demo/*') -split "`n" | ForEach-Object { $_.Trim() } | Where-Object { $_ }
+foreach ($rb in $remoteDemoBranches) {
+    $name = $rb -replace '^origin/', ''
+    Write-Host "Deleting remote branch: $name"
+    git push origin --delete $name 2>$null | Out-Null
+}
+
+# --- 6. prune worktree metadata -------------------------------------------
+git worktree prune 2>$null | Out-Null
+
+# Also delete any local demo/* branches the worktree removal left behind.
+$localDemo = (git branch --list 'demo/*') -split "`n" | ForEach-Object { $_.Trim().TrimStart('*').Trim() } | Where-Object { $_ }
+foreach ($lb in $localDemo) {
+    git branch -D $lb 2>$null | Out-Null
+}
+
+Write-Host ''
+Write-Host 'Reset complete.'

--- a/.github/skills/selfheal-demo/reset-demo.sh
+++ b/.github/skills/selfheal-demo/reset-demo.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# Clean up everything created by .github/skills/selfheal-demo/run-demo.sh.
+# Bash counterpart to .github/skills/selfheal-demo/reset-demo.ps1;
+# behaviour is identical.
+#
+# Usage:
+#   .github/skills/selfheal-demo/reset-demo.sh [--force]
+set -euo pipefail
+
+FORCE=0
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --force) FORCE=1; shift ;;
+        *) echo "Unknown arg: $1" >&2; exit 2 ;;
+    esac
+done
+
+for cmd in git gh; do
+    command -v "$cmd" >/dev/null 2>&1 || { echo "Required command not in PATH: $cmd" >&2; exit 1; }
+done
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+if [ "$FORCE" = 0 ]; then
+    echo 'This will close demo PRs/issues, delete demo/* branches on the remote,'
+    echo 'and force-remove demo worktrees. Re-run with --force to skip this prompt.'
+    printf 'Proceed? [y/N] '
+    read -r resp
+    case "$resp" in
+        y|Y|yes) ;;
+        *) echo 'Aborted.'; exit 0 ;;
+    esac
+fi
+
+# --- 1. close demo PRs ----------------------------------------------------
+demo_prs="$(gh pr list --state open --search '"[demo]" in:title' --json number --jq '.[].number' 2>/dev/null || true)"
+if [ -n "$demo_prs" ]; then
+    for n in $demo_prs; do
+        echo "Closing PR #$n"
+        gh pr close "$n" --delete-branch --comment 'Closed by reset-demo.sh.' >/dev/null 2>&1 || true
+    done
+else
+    echo 'No open demo PRs.'
+fi
+
+# --- 2. close demo tracking issues ----------------------------------------
+demo_issues="$(gh issue list --state open --label self-heal --search '"[demo]" in:title' --json number --jq '.[].number' 2>/dev/null || true)"
+if [ -n "$demo_issues" ]; then
+    for n in $demo_issues; do
+        echo "Closing issue #$n"
+        gh issue close "$n" --comment 'Closed by reset-demo.sh.' >/dev/null 2>&1 || true
+    done
+else
+    echo 'No open demo tracking issues.'
+fi
+
+# --- 3. remove worktrees recorded in state files --------------------------
+STATE_DIR="$REPO_ROOT/.github/skills/selfheal-demo/.state"
+declare -A CLEANED
+if [ -d "$STATE_DIR" ]; then
+    for f in "$STATE_DIR"/*.json; do
+        [ -e "$f" ] || continue
+        wt="$(grep -oE '"worktree":\s*"[^"]+"' "$f" | sed -E 's/.*"worktree":\s*"([^"]+)"/\1/' || true)"
+        if [ -n "$wt" ] && [ -e "$wt" ]; then
+            echo "Removing worktree: $wt"
+            git worktree remove --force "$wt" >/dev/null 2>&1 || true
+        fi
+        [ -n "$wt" ] && CLEANED["$wt"]=1
+        rm -f "$f"
+    done
+fi
+
+# --- 4. fallback worktree scan -------------------------------------------
+# Parse `git worktree list --porcelain`; remove any demo/* worktree we
+# haven't already cleaned via state file.
+current_path=''
+current_branch=''
+flush() {
+    if [ -n "$current_branch" ] && [[ "$current_branch" == refs/heads/demo/* ]]; then
+        if [ -z "${CLEANED[$current_path]:-}" ]; then
+            echo "Removing stray demo worktree: $current_path"
+            git worktree remove --force "$current_path" >/dev/null 2>&1 || true
+        fi
+    fi
+    current_path=''
+    current_branch=''
+}
+while IFS= read -r line || [ -n "$line" ]; do
+    case "$line" in
+        worktree\ *) [ -n "$current_path" ] && flush; current_path="${line#worktree }" ;;
+        branch\ *)   current_branch="${line#branch }" ;;
+        '')          flush ;;
+    esac
+done < <(git worktree list --porcelain 2>/dev/null || true)
+flush
+
+# --- 5. delete remaining demo/* remote branches ---------------------------
+git fetch --prune origin --quiet
+for rb in $(git branch -r --list 'origin/demo/*' 2>/dev/null | sed 's/^[[:space:]]*//'); do
+    name="${rb#origin/}"
+    echo "Deleting remote branch: $name"
+    git push origin --delete "$name" >/dev/null 2>&1 || true
+done
+
+# --- 6. prune worktree metadata + local branches --------------------------
+git worktree prune >/dev/null 2>&1 || true
+for lb in $(git branch --list 'demo/*' 2>/dev/null | sed 's/^[* ]*//'); do
+    git branch -D "$lb" >/dev/null 2>&1 || true
+done
+
+echo
+echo 'Reset complete.'

--- a/.github/skills/selfheal-demo/run-demo.ps1
+++ b/.github/skills/selfheal-demo/run-demo.ps1
@@ -1,0 +1,229 @@
+<#
+.SYNOPSIS
+    Customer-facing self-heal demo runner.
+
+.DESCRIPTION
+    Reproduces the @-mention-PR-author handoff pattern end-to-end:
+
+      1. Creates a throwaway worktree off origin/main at
+         ../selfheal-demo-<UTC-timestamp> (your main checkout is untouched).
+      2. Applies the same four mutations as scripts/inject.ps1 (Node 18 -> 22
+         + a helper using the Node-22-removed crypto.createCipher API).
+      3. Pushes the new branch `demo/<UTC-timestamp>` and opens a PR.
+      4. Records worktree path + branch in
+         .github/skills/selfheal-demo/.state/<branch>.json so
+         .github/skills/selfheal-demo/reset-demo.ps1 can clean up later.
+      5. Prints the PR URL and the gh-snippet you'll need after the
+         tracking issue appears.
+
+    The demo workflow .github/workflows/demo-self-heal.yml will react to the
+    failed CI run, open a tracking issue that @-mentions you, and post a
+    comment on the PR. You then assign Copilot to the issue (the manual
+    step the demo is designed to illustrate).
+
+    NOTE: The mutation block is a deliberate duplicate of scripts/inject.ps1
+    rather than a shared helper — the experiment harness must stay
+    byte-stable across trial batches. Keep both in sync if you change the
+    fixture.
+
+.PARAMETER NoPush
+    Build the worktree + commits locally, skip git push and gh pr create.
+    Useful for inspecting the inject diff.
+
+.PARAMETER Force
+    Skip "demo PR/issue/branch already exists" pre-flight refusal. Used by
+    the chat skill so it can run unattended.
+
+.NOTES
+    Requires: git, gh (authenticated as a user — App tokens cannot assign
+    Copilot, which is the whole point of this demo).
+#>
+[CmdletBinding()]
+param(
+    [switch] $NoPush,
+    [switch] $Force
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+# --- sanity ----------------------------------------------------------------
+foreach ($cmd in @('git', 'gh')) {
+    if (-not (Get-Command $cmd -ErrorAction SilentlyContinue)) {
+        throw "Required command not found in PATH: $cmd"
+    }
+}
+
+$repoRoot = (git rev-parse --show-toplevel).Trim()
+if (-not $repoRoot) { throw 'Not inside a git repo.' }
+Set-Location $repoRoot
+
+$packageJson = 'src/Web/package.json'
+$ciYaml      = '.github/workflows/ci.yml'
+foreach ($p in @($packageJson, $ciYaml)) {
+    if (-not (Test-Path $p)) { throw "Expected file missing: $p" }
+}
+
+# Pre-flight: refuse if a demo run is already in flight (unless -Force).
+if (-not $Force) {
+    $openDemoPrs = (gh pr list --state open --search '"[demo]" in:title' --json number --jq 'length' 2>$null)
+    if ($openDemoPrs -and [int]$openDemoPrs -gt 0) {
+        throw "An open demo PR already exists. Run '.github/skills/selfheal-demo/reset-demo.ps1' first, or pass -Force."
+    }
+}
+
+# --- worktree --------------------------------------------------------------
+$timestamp = (Get-Date).ToUniversalTime().ToString('yyyyMMdd-HHmmss')
+$branch    = "demo/$timestamp"
+$worktree  = Join-Path (Split-Path $repoRoot -Parent) "selfheal-demo-$timestamp"
+
+if (Test-Path $worktree) {
+    throw "Worktree path already exists: $worktree"
+}
+
+git fetch origin main --quiet
+git worktree add -b $branch $worktree origin/main | Out-Null
+Write-Host "Worktree: $worktree (branch: $branch)"
+
+Push-Location $worktree
+try {
+    # --- mutate package.json ---------------------------------------------
+    $pkgText = Get-Content $packageJson -Raw
+    if ($pkgText -notmatch '"node":\s*"18\.x"') {
+        throw "engines.node `"18.x`" not found in $packageJson (fixture drift?)"
+    }
+    $pkgText = $pkgText -replace '"node":\s*"18\.x"', '"node": "22.x"'
+    Set-Content -Path $packageJson -Value $pkgText -NoNewline
+
+    # --- mutate ci.yml ---------------------------------------------------
+    $ciText = Get-Content $ciYaml -Raw
+    if ($ciText -notmatch "node-version:\s*'18\.20\.4'") {
+        throw "node-version '18.20.4' not found in $ciYaml (fixture drift?)"
+    }
+    $ciText = $ciText -replace "node-version:\s*'18\.20\.4'", "node-version: '22.11.0'"
+    Set-Content -Path $ciYaml -Value $ciText -NoNewline
+
+    # --- write the helper that uses a Node-22-removed API ----------------
+    # SYNCED with scripts/inject.ps1; update both if the fixture changes.
+    $helper = @'
+'use strict';
+
+// Sign an opaque session token. Implementation predates Node 22.
+//
+// Note: crypto.createCipher is a legacy API. It derives a key from the
+// passphrase via OpenSSL's EVP_BytesToKey, which is not considered secure
+// for new code. Kept here for backward-compatibility with tokens issued by
+// the previous version of this service.
+const crypto = require('crypto');
+
+const ALGO = 'aes-192-cbc';
+
+function signToken(payload, passphrase) {
+  const cipher = crypto.createCipher(ALGO, passphrase);
+  let out = cipher.update(payload, 'utf8', 'hex');
+  out += cipher.final('hex');
+  return out;
+}
+
+function verifyToken(token, payload, passphrase) {
+  return signToken(payload, passphrase) === token;
+}
+
+module.exports = { signToken, verifyToken };
+'@
+    Set-Content -Path 'src/Web/crypto-helper.js' -Value $helper -NoNewline
+
+    $helperTest = @'
+'use strict';
+
+const { signToken, verifyToken } = require('./crypto-helper');
+
+describe('crypto-helper', () => {
+  test('signToken is deterministic for the same passphrase', () => {
+    const a = signToken('user-42', 'shared-secret');
+    const b = signToken('user-42', 'shared-secret');
+    expect(a).toBe(b);
+  });
+
+  test('verifyToken accepts a freshly signed token', () => {
+    const token = signToken('user-42', 'shared-secret');
+    expect(verifyToken(token, 'user-42', 'shared-secret')).toBe(true);
+  });
+});
+'@
+    Set-Content -Path 'src/Web/crypto-helper.test.js' -Value $helperTest -NoNewline
+
+    # --- commit ----------------------------------------------------------
+    git add $packageJson $ciYaml 'src/Web/crypto-helper.js' 'src/Web/crypto-helper.test.js'
+    git commit -m '[demo] Bump Node 18 -> 22 + add legacy crypto helper' | Out-Null
+}
+finally {
+    Pop-Location
+}
+
+# --- record state for reset-demo ------------------------------------------
+$stateDir  = Join-Path $repoRoot '.github/skills/selfheal-demo/.state'
+New-Item -ItemType Directory -Path $stateDir -Force | Out-Null
+$stateFile = Join-Path $stateDir ($timestamp + '.json')
+$state = [pscustomobject]@{
+    branch       = $branch
+    worktree     = $worktree
+    created_utc  = (Get-Date).ToUniversalTime().ToString('o')
+    pr_url       = $null
+}
+
+if ($NoPush) {
+    $state | ConvertTo-Json | Set-Content -Path $stateFile -Encoding utf8
+    Write-Host ''
+    Write-Host '[dry-run] Skipped push/PR.'
+    Write-Host "[dry-run] Inspect: cd $worktree; git diff origin/main..HEAD"
+    Write-Host "[dry-run] Clean up with: pwsh .github/skills/selfheal-demo/reset-demo.ps1"
+    return
+}
+
+# --- push + open PR --------------------------------------------------------
+Push-Location $worktree
+try {
+    git push -u origin $branch | Out-Null
+}
+finally {
+    Pop-Location
+}
+
+$prTitle = '[demo] Self-heal walkthrough: Node 22 + crypto.createCipher'
+$prBody  = @'
+> Opened by `.github/skills/selfheal-demo/run-demo.ps1` for the self-heal walkthrough demo.
+
+This PR deliberately breaks CI (Node bump removes an API the app uses).
+The `Demo Self-heal` workflow will:
+
+1. Open a tracking issue that @-mentions you with a one-click `gh` snippet.
+2. Comment on this PR linking to that issue.
+
+Then **you** assign Copilot to the tracking issue. The agent opens a fix PR
+off `main` (not off this branch).
+
+When done, run `pwsh .github/skills/selfheal-demo/reset-demo.ps1` to clean up everything this run
+created.
+'@
+
+gh pr create --base main --head $branch --title $prTitle --body $prBody | Out-Null
+$prUrl = (gh pr view $branch --json url --jq .url).Trim()
+
+$state.pr_url = $prUrl
+$state | ConvertTo-Json | Set-Content -Path $stateFile -Encoding utf8
+
+Write-Host ''
+Write-Host "Demo PR opened: $prUrl"
+Write-Host "Worktree:        $worktree"
+Write-Host "State recorded:  $stateFile"
+Write-Host ''
+Write-Host 'Next steps:'
+Write-Host '  1. Wait ~30s for CI to fail on the demo PR.'
+Write-Host '  2. The Demo Self-heal workflow will open a tracking issue and comment on the PR.'
+Write-Host '  3. From the tracking issue, click Assignees -> Copilot, OR run:'
+Write-Host '       gh issue edit <ISSUE_NUMBER> --add-assignee copilot-swe-agent'
+Write-Host '  4. The agent will open a fix PR off main within ~10 min (Batch 1 median: 8 min).'
+Write-Host ''
+Write-Host 'When finished:'
+Write-Host '  pwsh .github/skills/selfheal-demo/reset-demo.ps1'

--- a/.github/skills/selfheal-demo/run-demo.sh
+++ b/.github/skills/selfheal-demo/run-demo.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+# Customer-facing self-heal demo runner. Bash counterpart to
+# .github/skills/selfheal-demo/run-demo.ps1.
+# See that file for the full rationale; behaviour is identical.
+#
+# Usage:
+#   .github/skills/selfheal-demo/run-demo.sh [--no-push] [--force]
+#
+# Requires: git, gh (authenticated as a user — App tokens cannot assign
+# Copilot, which is the whole point of this demo).
+set -euo pipefail
+
+NO_PUSH=0
+FORCE=0
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --no-push) NO_PUSH=1; shift ;;
+        --force)   FORCE=1;   shift ;;
+        *) echo "Unknown arg: $1" >&2; exit 2 ;;
+    esac
+done
+
+for cmd in git gh; do
+    command -v "$cmd" >/dev/null 2>&1 || { echo "Required command not in PATH: $cmd" >&2; exit 1; }
+done
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+PKG='src/Web/package.json'
+CI='.github/workflows/ci.yml'
+HELPER='src/Web/crypto-helper.js'
+HELPER_TEST='src/Web/crypto-helper.test.js'
+
+[ -f "$PKG" ] || { echo "Missing $PKG" >&2; exit 1; }
+[ -f "$CI"  ] || { echo "Missing $CI"  >&2; exit 1; }
+
+# Pre-flight: refuse if a demo run is already in flight (unless --force).
+if [ "$FORCE" = 0 ]; then
+    open_demo="$(gh pr list --state open --search '"[demo]" in:title' --json number --jq 'length' 2>/dev/null || echo 0)"
+    if [ -n "$open_demo" ] && [ "$open_demo" -gt 0 ]; then
+        echo "An open demo PR already exists. Run '.github/skills/selfheal-demo/reset-demo.sh' first, or pass --force." >&2
+        exit 1
+    fi
+fi
+
+TS="$(date -u +%Y%m%d-%H%M%S)"
+BRANCH="demo/$TS"
+WORKTREE="$(dirname "$REPO_ROOT")/selfheal-demo-$TS"
+
+if [ -e "$WORKTREE" ]; then
+    echo "Worktree path already exists: $WORKTREE" >&2
+    exit 1
+fi
+
+git fetch origin main --quiet
+git worktree add -b "$BRANCH" "$WORKTREE" origin/main >/dev/null
+echo "Worktree: $WORKTREE (branch: $BRANCH)"
+
+(
+    cd "$WORKTREE"
+
+    # package.json: "node": "18.x" -> "22.x"
+    if ! grep -qE '"node":\s*"18\.x"' "$PKG"; then
+        echo "engines.node \"18.x\" not found in $PKG (fixture drift?)" >&2
+        exit 1
+    fi
+    perl -0777 -i -pe 's|"node":\s*"18\.x"|"node": "22.x"|' "$PKG"
+
+    # ci.yml: node-version: '18.20.4' -> '22.11.0'
+    if ! grep -qE "node-version:\s*'18\.20\.4'" "$CI"; then
+        echo "node-version '18.20.4' not found in $CI (fixture drift?)" >&2
+        exit 1
+    fi
+    perl -0777 -i -pe "s|node-version:\s*'18\.20\.4'|node-version: '22.11.0'|" "$CI"
+
+    # SYNCED with scripts/inject.sh; update both if the fixture changes.
+    cat > "$HELPER" <<'EOF'
+'use strict';
+
+// Sign an opaque session token. Implementation predates Node 22.
+//
+// Note: crypto.createCipher is a legacy API. It derives a key from the
+// passphrase via OpenSSL's EVP_BytesToKey, which is not considered secure
+// for new code. Kept here for backward-compatibility with tokens issued by
+// the previous version of this service.
+const crypto = require('crypto');
+
+const ALGO = 'aes-192-cbc';
+
+function signToken(payload, passphrase) {
+  const cipher = crypto.createCipher(ALGO, passphrase);
+  let out = cipher.update(payload, 'utf8', 'hex');
+  out += cipher.final('hex');
+  return out;
+}
+
+function verifyToken(token, payload, passphrase) {
+  return signToken(payload, passphrase) === token;
+}
+
+module.exports = { signToken, verifyToken };
+EOF
+
+    cat > "$HELPER_TEST" <<'EOF'
+'use strict';
+
+const { signToken, verifyToken } = require('./crypto-helper');
+
+describe('crypto-helper', () => {
+  test('signToken is deterministic for the same passphrase', () => {
+    const a = signToken('user-42', 'shared-secret');
+    const b = signToken('user-42', 'shared-secret');
+    expect(a).toBe(b);
+  });
+
+  test('verifyToken accepts a freshly signed token', () => {
+    const token = signToken('user-42', 'shared-secret');
+    expect(verifyToken(token, 'user-42', 'shared-secret')).toBe(true);
+  });
+});
+EOF
+
+    git add "$PKG" "$CI" "$HELPER" "$HELPER_TEST"
+    git commit -m '[demo] Bump Node 18 -> 22 + add legacy crypto helper' >/dev/null
+)
+
+STATE_DIR="$REPO_ROOT/.github/skills/selfheal-demo/.state"
+mkdir -p "$STATE_DIR"
+STATE_FILE="$STATE_DIR/$TS.json"
+CREATED="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+if [ "$NO_PUSH" = 1 ]; then
+    cat > "$STATE_FILE" <<EOF
+{
+  "branch": "$BRANCH",
+  "worktree": "$WORKTREE",
+  "created_utc": "$CREATED",
+  "pr_url": null
+}
+EOF
+    echo
+    echo "[dry-run] Skipped push/PR."
+    echo "[dry-run] Inspect: cd $WORKTREE; git diff origin/main..HEAD"
+    echo "[dry-run] Clean up with: .github/skills/selfheal-demo/reset-demo.sh"
+    exit 0
+fi
+
+(
+    cd "$WORKTREE"
+    git push -u origin "$BRANCH" >/dev/null
+)
+
+PR_BODY=$(cat <<'EOF'
+> Opened by `.github/skills/selfheal-demo/run-demo.sh` for the self-heal walkthrough demo.
+
+This PR deliberately breaks CI (Node bump removes an API the app uses).
+The `Demo Self-heal` workflow will:
+
+1. Open a tracking issue that @-mentions you with a one-click `gh` snippet.
+2. Comment on this PR linking to that issue.
+
+Then **you** assign Copilot to the tracking issue. The agent opens a fix PR
+off `main` (not off this branch).
+
+When done, run `.github/skills/selfheal-demo/reset-demo.sh` to clean up everything this run created.
+EOF
+)
+
+gh pr create --base main --head "$BRANCH" \
+    --title '[demo] Self-heal walkthrough: Node 22 + crypto.createCipher' \
+    --body "$PR_BODY" >/dev/null
+PR_URL="$(gh pr view "$BRANCH" --json url --jq .url)"
+
+cat > "$STATE_FILE" <<EOF
+{
+  "branch": "$BRANCH",
+  "worktree": "$WORKTREE",
+  "created_utc": "$CREATED",
+  "pr_url": "$PR_URL"
+}
+EOF
+
+echo
+echo "Demo PR opened: $PR_URL"
+echo "Worktree:        $WORKTREE"
+echo "State recorded:  $STATE_FILE"
+echo
+echo 'Next steps:'
+echo '  1. Wait ~30s for CI to fail on the demo PR.'
+echo '  2. The Demo Self-heal workflow will open a tracking issue and comment on the PR.'
+echo '  3. From the tracking issue, click Assignees -> Copilot, OR run:'
+echo '       gh issue edit <ISSUE_NUMBER> --add-assignee copilot-swe-agent'
+echo '  4. The agent will open a fix PR off main within ~10 min (Batch 1 median: 8 min).'
+echo
+echo 'When finished:'
+echo '  .github/skills/selfheal-demo/reset-demo.sh'

--- a/.github/workflows/demo-self-heal.yml
+++ b/.github/workflows/demo-self-heal.yml
@@ -1,0 +1,321 @@
+# Self-heal responder (DEMO variant).
+#
+# Customer-facing walkthrough of the @-mention-PR-author handoff pattern.
+# Listens for completed CI runs on `demo/*` branches only. The experiment
+# harness's `self-heal.yml` ignores `demo/*` branches, so trial data stays
+# byte-stable across batches.
+#
+# Pipeline:
+#   1. classify              — failed job + last 50 log lines + dedupe key
+#   2. resolve-pr-context    — source PR number/url/author from workflow_run
+#   3. open-or-update-issue  — render template (with @author mention),
+#                              create/update tracking issue
+#   4. comment-on-source-pr  — post (or update) a comment on the source PR
+#                              linking to the tracking issue
+#
+# Agent assignment is intentionally MANUAL. See:
+#   - `.github/DEMO_CI_FAILURE_TEMPLATE.md` "Why a human click?"
+#   - `.github/skills/selfheal-demo/README.md` for the full design rationale
+
+name: Demo Self-heal
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+
+permissions: {}
+
+env:
+  UPSTREAM_RUN_ID: ${{ github.event.workflow_run.id }}
+  UPSTREAM_RUN_NUMBER: ${{ github.event.workflow_run.run_number }}
+  UPSTREAM_RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
+  UPSTREAM_RUN_URL: ${{ github.event.workflow_run.html_url }}
+  UPSTREAM_WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
+  UPSTREAM_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+  UPSTREAM_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+  UPSTREAM_TRIGGERING_ACTOR: ${{ github.event.workflow_run.triggering_actor.login }}
+
+jobs:
+  classify:
+    name: classify failure
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Demo-scoped: only react to failures on demo/* branches. Same actor
+    # guards as the experiment responder.
+    if: >-
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.triggering_actor.login != 'copilot-swe-agent[bot]' &&
+      github.event.workflow_run.triggering_actor.login != 'github-actions[bot]' &&
+      startsWith(github.event.workflow_run.head_branch, 'demo/')
+    permissions:
+      actions: read
+      contents: read
+    outputs:
+      failed_job_name: ${{ steps.detect.outputs.failed_job_name }}
+      log_tail_b64: ${{ steps.detect.outputs.log_tail_b64 }}
+      dedupe_key: ${{ steps.detect.outputs.dedupe_key }}
+    steps:
+      - name: Inspect failed jobs and logs
+        id: detect
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const crypto = require('crypto');
+            const runId = Number(process.env.UPSTREAM_RUN_ID);
+
+            const jobs = await github.paginate(github.rest.actions.listJobsForWorkflowRun, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: runId,
+              per_page: 100,
+            });
+
+            const failed = jobs.find(j => j.conclusion === 'failure');
+            const failedName = failed ? failed.name : 'unknown';
+            const failedJobId = failed ? failed.id : null;
+            core.info(`Failed job: ${failedName} (id=${failedJobId})`);
+
+            let logTail = '(no log content available)';
+            if (failedJobId) {
+              try {
+                const logsResp = await github.rest.actions.downloadJobLogsForWorkflowRun({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  job_id: failedJobId,
+                });
+                const raw = typeof logsResp.data === 'string'
+                  ? logsResp.data
+                  : Buffer.from(logsResp.data).toString('utf8');
+                const ansi = /\x1b\[[0-9;]*[A-Za-z]/g;
+                const ts = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z\s?/;
+                const lines = raw
+                  .replace(ansi, '')
+                  .split('\n')
+                  .map(l => l.replace(ts, ''))
+                  .filter(l => l.trim().length > 0);
+                logTail = lines.slice(-50).join('\n');
+              } catch (err) {
+                core.warning(`Could not download job logs: ${err.message}`);
+              }
+            }
+
+            const dedupeRaw = `${process.env.UPSTREAM_WORKFLOW_NAME}|${process.env.UPSTREAM_HEAD_BRANCH}|${failedName}`;
+            const dedupeKey = crypto.createHash('sha1').update(dedupeRaw).digest('hex').slice(0, 12);
+
+            core.setOutput('failed_job_name', failedName);
+            core.setOutput('log_tail_b64', Buffer.from(logTail, 'utf8').toString('base64'));
+            core.setOutput('dedupe_key', dedupeKey);
+
+  resolve-pr-context:
+    name: resolve source PR context
+    needs: classify
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      pr_number: ${{ steps.resolve.outputs.pr_number }}
+      pr_url: ${{ steps.resolve.outputs.pr_url }}
+      pr_author: ${{ steps.resolve.outputs.pr_author }}
+    steps:
+      - name: Resolve PR from workflow_run
+        id: resolve
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            // Primary: workflow_run payload often carries pull_requests[].
+            // It can be empty for cross-fork PRs; fall back to a head_sha lookup.
+            let pr = (context.payload.workflow_run.pull_requests || [])[0];
+
+            if (!pr) {
+              const sha = process.env.UPSTREAM_HEAD_SHA;
+              core.info(`No PR in workflow_run payload; searching by head SHA ${sha}`);
+              const prs = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                commit_sha: sha,
+              });
+              pr = (prs.data || [])[0];
+            }
+
+            if (!pr) {
+              core.warning('Could not resolve a source PR for this run; using fallback values.');
+              core.setOutput('pr_number', '');
+              core.setOutput('pr_url', '');
+              core.setOutput('pr_author', '');
+              return;
+            }
+
+            // Normalise: payload PR has `number` + `url` (api), repos API PR has
+            // `number` + `html_url` + `user.login`.
+            const number = pr.number;
+            let url = pr.html_url;
+            let author = pr.user && pr.user.login;
+
+            if (!url || !author) {
+              const full = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: number,
+              });
+              url = url || full.data.html_url;
+              author = author || full.data.user.login;
+            }
+
+            core.info(`Resolved source PR #${number} by @${author}: ${url}`);
+            core.setOutput('pr_number', String(number));
+            core.setOutput('pr_url', url);
+            core.setOutput('pr_author', author);
+
+  open-or-update-issue:
+    name: open or update tracking issue
+    needs: [classify, resolve-pr-context]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: write
+    outputs:
+      issue_number: ${{ steps.upsert.outputs.issue_number }}
+      issue_url: ${{ steps.upsert.outputs.issue_url }}
+    steps:
+      - name: Checkout (need template)
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Render issue body from template
+        id: render
+        env:
+          WORKFLOW_NAME: ${{ env.UPSTREAM_WORKFLOW_NAME }}
+          FAILED_JOB_NAME: ${{ needs.classify.outputs.failed_job_name }}
+          HEAD_BRANCH: ${{ env.UPSTREAM_HEAD_BRANCH }}
+          HEAD_SHA: ${{ env.UPSTREAM_HEAD_SHA }}
+          RUN_NUMBER: ${{ env.UPSTREAM_RUN_NUMBER }}
+          RUN_ATTEMPT: ${{ env.UPSTREAM_RUN_ATTEMPT }}
+          RUN_URL: ${{ env.UPSTREAM_RUN_URL }}
+          TRIGGERING_ACTOR: ${{ env.UPSTREAM_TRIGGERING_ACTOR }}
+          DEDUPE_KEY: ${{ needs.classify.outputs.dedupe_key }}
+          LOG_TAIL_B64: ${{ needs.classify.outputs.log_tail_b64 }}
+          PR_NUMBER: ${{ needs.resolve-pr-context.outputs.pr_number }}
+          PR_URL: ${{ needs.resolve-pr-context.outputs.pr_url }}
+          PR_AUTHOR: ${{ needs.resolve-pr-context.outputs.pr_author }}
+        run: |
+          set -euo pipefail
+          LOG_TAIL="$(printf '%s' "$LOG_TAIL_B64" | base64 -d)"
+          export LOG_TAIL
+
+          # envsubst with an explicit allowlist — never substitute arbitrary $VAR from log body.
+          ALLOWED='${WORKFLOW_NAME} ${FAILED_JOB_NAME} ${HEAD_BRANCH} ${HEAD_SHA} ${RUN_NUMBER} ${RUN_ATTEMPT} ${RUN_URL} ${TRIGGERING_ACTOR} ${DEDUPE_KEY} ${LOG_TAIL} ${PR_NUMBER} ${PR_URL} ${PR_AUTHOR}'
+          envsubst "$ALLOWED" < .github/DEMO_CI_FAILURE_TEMPLATE.md > /tmp/issue-body.md
+          echo "body_path=/tmp/issue-body.md" >> "$GITHUB_OUTPUT"
+
+      - name: Ensure self-heal label exists
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh label create self-heal --color 0E8A16 --description "Tracking issue opened by the self-heal responder" --force
+
+      - name: Upsert issue
+        id: upsert
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DEDUPE_KEY: ${{ needs.classify.outputs.dedupe_key }}
+          FAILED_JOB_NAME: ${{ needs.classify.outputs.failed_job_name }}
+          HEAD_BRANCH: ${{ env.UPSTREAM_HEAD_BRANCH }}
+          WORKFLOW_NAME: ${{ env.UPSTREAM_WORKFLOW_NAME }}
+          BODY_PATH: ${{ steps.render.outputs.body_path }}
+        run: |
+          set -euo pipefail
+
+          DEDUPE_TOKEN="sh-${DEDUPE_KEY}"
+          # `[demo]` prefix lets `.github/skills/selfheal-demo/reset-demo.*`
+          # find these by title filter.
+          TITLE="[demo] [self-heal] ${WORKFLOW_NAME} failed: ${FAILED_JOB_NAME} on ${HEAD_BRANCH} (${DEDUPE_TOKEN})"
+
+          existing="$(gh issue list \
+            --state open \
+            --label self-heal \
+            --search "\"${DEDUPE_TOKEN}\" in:title" \
+            --json number \
+            --jq '.[0].number // empty')"
+
+          if [ -z "$existing" ]; then
+            url="$(gh issue create \
+              --title "$TITLE" \
+              --body-file "$BODY_PATH" \
+              --label self-heal)"
+            num="${url##*/}"
+            echo "issue_number=$num" >> "$GITHUB_OUTPUT"
+            echo "issue_url=$url" >> "$GITHUB_OUTPUT"
+            echo "::notice::Tracking issue #$num created. Author must assign \`copilot-swe-agent\` to start the agent."
+          else
+            gh issue comment "$existing" --body-file "$BODY_PATH"
+            url="$(gh issue view "$existing" --json url --jq .url)"
+            echo "issue_number=$existing" >> "$GITHUB_OUTPUT"
+            echo "issue_url=$url" >> "$GITHUB_OUTPUT"
+            echo "::notice::Tracking issue #$existing updated."
+          fi
+
+  comment-on-source-pr:
+    name: comment on source PR
+    needs: [resolve-pr-context, open-or-update-issue]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: needs.resolve-pr-context.outputs.pr_number != ''
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Post or update tracking link
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        env:
+          PR_NUMBER: ${{ needs.resolve-pr-context.outputs.pr_number }}
+          ISSUE_NUMBER: ${{ needs.open-or-update-issue.outputs.issue_number }}
+          ISSUE_URL: ${{ needs.open-or-update-issue.outputs.issue_url }}
+        with:
+          script: |
+            // HTML-comment marker keeps repeat runs idempotent — find an existing
+            // comment by marker and update in place rather than spamming the PR.
+            const MARKER = '<!-- selfheal-demo:tracking -->';
+            const prNumber = Number(process.env.PR_NUMBER);
+            const issueNumber = process.env.ISSUE_NUMBER;
+            const issueUrl = process.env.ISSUE_URL;
+
+            const body = [
+              MARKER,
+              `**CI failed.** Tracking issue: [#${issueNumber}](${issueUrl})`,
+              '',
+              'To start the cloud agent on this fix, assign **Copilot** to that',
+              'issue (Assignees sidebar, or `gh issue edit ' + issueNumber +
+                ' --add-assignee copilot-swe-agent`).',
+              '',
+              'See [the demo walkthrough](../tree/main/.github/skills/selfheal-demo) for why this is a manual step.',
+            ].join('\n');
+
+            const existing = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              per_page: 100,
+            });
+            const prior = existing.find(c => typeof c.body === 'string' && c.body.includes(MARKER));
+
+            if (prior) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: prior.id,
+                body,
+              });
+              core.info(`Updated existing tracking-link comment on PR #${prNumber}.`);
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body,
+              });
+              core.info(`Posted tracking-link comment on PR #${prNumber}.`);
+            }

--- a/.github/workflows/self-heal.yml
+++ b/.github/workflows/self-heal.yml
@@ -49,10 +49,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     # Fail-fast filter: only failures, never react to our own bot, never react to PRs from forks.
+    # `demo/*` branches are handled by `demo-self-heal.yml` (customer-facing
+    # walkthrough); skip here so the experiment harness behaviour stays
+    # byte-stable across trial batches.
     if: >-
       github.event.workflow_run.conclusion == 'failure' &&
       github.event.workflow_run.triggering_actor.login != 'copilot-swe-agent[bot]' &&
-      github.event.workflow_run.triggering_actor.login != 'github-actions[bot]'
+      github.event.workflow_run.triggering_actor.login != 'github-actions[bot]' &&
+      !startsWith(github.event.workflow_run.head_branch, 'demo/')
     permissions:
       actions: read
       contents: read

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ Thumbs.db
 # Env
 .env
 .env.local
+
+# Demo runner state (per-run worktree/branch records)
+.github/skills/selfheal-demo/.state/

--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ The fixture is small and deliberately uninteresting; the interesting bits live i
 rationale) and [experiments/trials.jsonl](experiments/trials.jsonl) (append-only
 trial log).
 
+See also [.github/skills/selfheal-demo/](.github/skills/selfheal-demo/) for
+a customer-facing walkthrough of the @-mention-PR-author handoff pattern
+(built on the same fixture; isolated from the experiment harness so trial
+data stays byte-stable). Packaged as a VS Code skill so it's chat-invokable.
+
 ## Predecessor
 
 Architectural patterns (issue-assignment dispatch, App-token minting, SHA-pinned
@@ -29,14 +34,17 @@ actions, per-job `permissions:` blocks, dedupe key) are carried from
 
 ```
 .github/
-  CI_FAILURE_TEMPLATE.md    Issue body template (envsubst-rendered)
-  copilot-instructions.md   Per-repo agent guardrails (filled in X6)
+  CI_FAILURE_TEMPLATE.md       Issue body template (envsubst-rendered)
+  DEMO_CI_FAILURE_TEMPLATE.md  Issue body template for the demo flow
+  copilot-instructions.md      Per-repo agent guardrails (filled in X6)
   workflows/
-    ci.yml                  Builds + tests src/Web/
-    self-heal.yml           classify → open-or-update-issue → assign-copilot
-src/Web/                    Node fixture (Express + jest)
-scripts/                    Inject scripts (PowerShell + bash)
-experiments/                Trial procedure + log
+    ci.yml                     Builds + tests src/Web/
+    self-heal.yml              Experiment responder (skips demo/* branches)
+    demo-self-heal.yml         Demo responder (scoped to demo/* branches)
+src/Web/                       Node fixture (Express + jest)
+scripts/                       Experiment inject scripts (PowerShell + bash)
+experiments/                   Trial procedure + log
+.github/skills/selfheal-demo/  Customer-facing walkthrough (run/reset + SKILL.md)
 ```
 
 ## External setup (one-time, not scripted)


### PR DESCRIPTION
Adds the `@-mention-PR-author` handoff demo as a chat-invokable VS Code skill at `.github/skills/selfheal-demo/`.

## What's new

- **`demo-self-heal.yml`** — `workflow_run` responder scoped to `demo/*` branches. Resolves the source PR, opens a tracking issue that `@`-mentions the PR author with a copy-paste `gh issue edit ... --add-assignee copilot-swe-agent` snippet, posts an idempotent comment on the source PR.
- **`DEMO_CI_FAILURE_TEMPLATE.md`** — tracking-issue body with the author mention and a "why a human click" explainer (no PAT, no stored OAuth refresh).
- **`run-demo.{ps1,sh}`** — throwaway worktree off `origin/main`, applies the validated Node-22 + `crypto.createCipher` inject, opens demo PR, records state for `reset-demo`.
- **`reset-demo.{ps1,sh}`** — idempotent cleanup (PRs, issues, worktrees, remote `demo/*` branches).
- **`SKILL.md`** — chat trigger phrases for run/reset; auto-discovered from `.github/skills/`.

## Experiment harness impact

`self-heal.yml` skips `demo/*` branches so trial data stays byte-stable across batches. The fixture (`src/Web/`) and inject mutations are shared; `run-demo` deliberately duplicates the mutation block from `scripts/inject.ps1` rather than refactor a shared helper, again to keep the experiment scripts byte-stable.

## How to smoke-test after merge

```pwsh
pwsh .github/skills/selfheal-demo/run-demo.ps1
# wait ~30s; tracking issue + PR comment should appear
# manually assign Copilot to the tracking issue
# wait ~3-10 min for fix PR
pwsh .github/skills/selfheal-demo/reset-demo.ps1
```

Or from VS Code chat: "run the self-heal demo" / "reset the self-heal demo".