### PR TITLE
[demo] Self-heal walkthrough: Node 22 + crypto.createCipher

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
         with:
-          node-version: '18.20.4'
+          node-version: '22.11.0'
           cache: 'npm'
           cache-dependency-path: src/Web/package-lock.json
 

--- a/src/Web/crypto-helper.js
+++ b/src/Web/crypto-helper.js
@@ -5,6 +5,11 @@ const crypto = require('crypto');
 const ALGO = 'aes-192-cbc';
 const KEY_LEN = 24; // aes-192 requires a 24-byte key
 const IV_LEN = 16;  // AES CBC requires a 16-byte IV
+// A fixed salt is intentional here: the service must produce the same token for
+// the same (payload, passphrase) pair so that existing tokens remain verifiable
+// after a server restart. This is a known security trade-off — a static salt
+// makes key derivation deterministic but predictable. New code should use a
+// random per-token salt stored alongside the ciphertext.
 const SALT = 'selfheal-experiments-static-salt';
 
 // Derive a deterministic key and IV from the passphrase using scrypt.

--- a/src/Web/crypto-helper.js
+++ b/src/Web/crypto-helper.js
@@ -1,17 +1,21 @@
 'use strict';
 
-// Sign an opaque session token. Implementation predates Node 22.
-//
-// Note: crypto.createCipher is a legacy API. It derives a key from the
-// passphrase via OpenSSL's EVP_BytesToKey, which is not considered secure
-// for new code. Kept here for backward-compatibility with tokens issued by
-// the previous version of this service.
 const crypto = require('crypto');
 
 const ALGO = 'aes-192-cbc';
+const KEY_LEN = 24; // aes-192 requires a 24-byte key
+const IV_LEN = 16;  // AES CBC requires a 16-byte IV
+const SALT = 'selfheal-experiments-static-salt';
+
+// Derive a deterministic key and IV from the passphrase using scrypt.
+function deriveKeyAndIv(passphrase) {
+  const derived = crypto.scryptSync(passphrase, SALT, KEY_LEN + IV_LEN);
+  return { key: derived.subarray(0, KEY_LEN), iv: derived.subarray(KEY_LEN) };
+}
 
 function signToken(payload, passphrase) {
-  const cipher = crypto.createCipher(ALGO, passphrase);
+  const { key, iv } = deriveKeyAndIv(passphrase);
+  const cipher = crypto.createCipheriv(ALGO, key, iv);
   let out = cipher.update(payload, 'utf8', 'hex');
   out += cipher.final('hex');
   return out;

--- a/src/Web/crypto-helper.js
+++ b/src/Web/crypto-helper.js
@@ -1,0 +1,24 @@
+'use strict';
+
+// Sign an opaque session token. Implementation predates Node 22.
+//
+// Note: crypto.createCipher is a legacy API. It derives a key from the
+// passphrase via OpenSSL's EVP_BytesToKey, which is not considered secure
+// for new code. Kept here for backward-compatibility with tokens issued by
+// the previous version of this service.
+const crypto = require('crypto');
+
+const ALGO = 'aes-192-cbc';
+
+function signToken(payload, passphrase) {
+  const cipher = crypto.createCipher(ALGO, passphrase);
+  let out = cipher.update(payload, 'utf8', 'hex');
+  out += cipher.final('hex');
+  return out;
+}
+
+function verifyToken(token, payload, passphrase) {
+  return signToken(payload, passphrase) === token;
+}
+
+module.exports = { signToken, verifyToken };

--- a/src/Web/crypto-helper.test.js
+++ b/src/Web/crypto-helper.test.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const { signToken, verifyToken } = require('./crypto-helper');
+
+describe('crypto-helper', () => {
+  test('signToken is deterministic for the same passphrase', () => {
+    const a = signToken('user-42', 'shared-secret');
+    const b = signToken('user-42', 'shared-secret');
+    expect(a).toBe(b);
+  });
+
+  test('verifyToken accepts a freshly signed token', () => {
+    const token = signToken('user-42', 'shared-secret');
+    expect(verifyToken(token, 'user-42', 'shared-secret')).toBe(true);
+  });
+});

--- a/src/Web/package-lock.json
+++ b/src/Web/package-lock.json
@@ -17,7 +17,7 @@
         "supertest": "6.3.4"
       },
       "engines": {
-        "node": "18.x"
+        "node": "22.x"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/src/Web/package.json
+++ b/src/Web/package.json
@@ -5,7 +5,7 @@
   "description": "Tiny Express fixture for selfheal-experiments. Intentionally boring.",
   "main": "index.js",
   "engines": {
-    "node": "18.x"
+    "node": "22.x"
   },
   "scripts": {
     "start": "node index.js",


### PR DESCRIPTION
> Opened by `.github/skills/selfheal-demo/run-demo.ps1` for the self-heal walkthrough demo.

This PR deliberately breaks CI (Node bump removes an API the app uses).
The `Demo Self-heal` workflow will:

1. Open a tracking issue that @-mentions you with a one-click `gh` snippet.
2. Comment on this PR linking to that issue.

Then **you** assign Copilot to the tracking issue. The agent opens a fix PR
off `main` (not off this branch).

When done, run `pwsh .github/skills/selfheal-demo/reset-demo.ps1` to clean up everything this run
created.